### PR TITLE
Loosen the pin on the Python package `cffi`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ altgraph==0.17.2
 bcrypt==4.0.0
 bdist-mpkg==0.5.0
 certifi==2022.6.15
-cffi==1.15.1
+cffi>=1.15.1
 chardet==5.0.0
 charset-normalizer==2.1.1
 click==8.1.3


### PR DESCRIPTION
Python 3.13.2 (the currently-available Python3 on Kali Linux) requires a newer version of the `cffi` package, so this project cannot support recent versions of Kali Linux without this change.