### PR TITLE
Fix typo in `python_version`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -47,4 +47,4 @@ Werkzeug = "*"
 zipp = "*"
 
 [requires]
-python_version = "3.12"
+python_version = "3.13"


### PR DESCRIPTION
The `Pipfile.lock` was created with Python 3.13, and that is the version of Python we intend to use with this tool on Kali Linux.